### PR TITLE
ClougWatch Logs Cloud Formation Syntax

### DIFF
--- a/logs-loggroup.sublime-snippet
+++ b/logs-loggroup.sublime-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+"${1:logLogGroup}": {
+  "Type": "AWS::Logs::LogGroup",
+  "Properties": {
+    "RetentionInDays": "${2}"
+  }
+}
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <tabTrigger>logs-loggroup</tabTrigger>
+    <!-- Optional: Set a scope to limit where the snippet will trigger -->
+    <scope>source.cloudformation</scope>
+</snippet>

--- a/logs-metricfilter.sublime-snippet
+++ b/logs-metricfilter.sublime-snippet
@@ -1,0 +1,16 @@
+<snippet>
+	<content><![CDATA[
+"${1:logsMetricFilter}": {
+  "Type": "AWS::Logs::MetricFilter",    
+  "Properties": {
+    "FilterPattern": [ "${2}" ],
+    "LogGroupName": "${3}",
+    "MetricTransformations": [ ${4} ]
+  }
+}
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <tabTrigger>logs-metricfilter</tabTrigger>
+    <!-- Optional: Set a scope to limit where the snippet will trigger -->
+    <scope>source.cloudformation</scope>
+</snippet>


### PR DESCRIPTION
CloudFormation for CloudWatch Logs resource:
* AWS::Logs::LogGroup - http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html
* AWS::Logs::MetricFilter - http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-metricfilter.html